### PR TITLE
Default timeouts

### DIFF
--- a/cli/run.go
+++ b/cli/run.go
@@ -42,6 +42,9 @@ func Run(ctx context.Context, root *cmds.Command,
 			return err
 		}
 		req.Context, cancel = context.WithTimeout(req.Context, timeout)
+	} else if req.Command.RunTimeout != 0 {
+		// Use command default timeout when available
+		req.Context, cancel = context.WithTimeout(req.Context, req.Command.RunTimeout)
 	} else {
 		req.Context, cancel = context.WithCancel(req.Context)
 	}

--- a/error.go
+++ b/error.go
@@ -22,6 +22,8 @@ const (
 	// ErrForbidden is returned when the client doesn't have permission to
 	// perform the requested operation.
 	ErrForbidden
+	// ErrorTimedOut is returned when the operation had timed out or was canceled.
+	ErrTimedOut
 )
 
 func (e ErrorType) Error() string {
@@ -40,6 +42,8 @@ func (e ErrorType) String() string {
 		return "rate limited"
 	case ErrForbidden:
 		return "request forbidden"
+	case ErrTimedOut:
+		return "timed out"
 	default:
 		return "unknown error code"
 	}

--- a/go.mod
+++ b/go.mod
@@ -8,3 +8,5 @@ require (
 	github.com/texttheater/golang-levenshtein v0.0.0-20180516184445-d188e65d659e
 	golang.org/x/crypto v0.0.0-20190513172903-22d7a77e9e5f
 )
+
+go 1.13

--- a/http/handler.go
+++ b/http/handler.go
@@ -138,6 +138,9 @@ func (h *handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 			return
 		}
 		req.Context, cancel = context.WithTimeout(req.Context, timeout)
+	} else if req.Command.RunTimeout != 0 {
+		// Use command default timeout when available
+		req.Context, cancel = context.WithTimeout(req.Context, req.Command.RunTimeout)
 	} else {
 		req.Context, cancel = context.WithCancel(req.Context)
 	}

--- a/http/responseemitter.go
+++ b/http/responseemitter.go
@@ -1,6 +1,7 @@
 package http
 
 import (
+	"context"
 	"fmt"
 	"io"
 	"net/http"
@@ -174,6 +175,10 @@ func (re *responseEmitter) closeWithError(err error) error {
 	case io.EOF:
 		// not a real error
 		err = nil
+	case context.Canceled:
+		err = &cmds.Error{Message: "canceled", Code: cmds.ErrTimedOut}
+	case context.DeadlineExceeded:
+		err = &cmds.Error{Message: "timed out", Code: cmds.ErrTimedOut}
 	default:
 		// make sure this is *always* of type *cmds.Error
 		switch e := err.(type) {


### PR DESCRIPTION
- Add a default timeout for commands with `RunTimeout`, if set to `X`, `Run` only executes for `X` duration
- The global --timeout still overrides the default `RunTimeout`
- The timeout works in all 3 modes
  * CLI legacy mode, it is wrapped around the `Run` inside `Execute`
  * CLI online mode, it is using net/http's own timeout mechanism in `Execute`'s `send`, and the result is checked for timeout
  * HTTP mode, it is wrapped around the `Run` inside command `Call`, which is used by the http handler