### PR TITLE
BTFSBTT-227: Fix btfs add command SEGV cases

### DIFF
--- a/cli/run.go
+++ b/cli/run.go
@@ -3,11 +3,12 @@ package cli
 import (
 	"context"
 	"fmt"
-	"github.com/TRON-US/go-btfs-cmds"
 	"io"
 	"os"
 	"strings"
 	"time"
+
+	"github.com/TRON-US/go-btfs-cmds"
 )
 
 // ExitError is the error used when a specific exit code needs to be returned.

--- a/cli/run.go
+++ b/cli/run.go
@@ -3,12 +3,11 @@ package cli
 import (
 	"context"
 	"fmt"
+	"github.com/TRON-US/go-btfs-cmds"
 	"io"
 	"os"
 	"strings"
 	"time"
-
-	"github.com/TRON-US/go-btfs-cmds"
 )
 
 // ExitError is the error used when a specific exit code needs to be returned.
@@ -32,23 +31,6 @@ func Run(ctx context.Context, root *cmds.Command,
 	}
 
 	req, errParse := Parse(ctx, cmdline[1:], stdin, root)
-
-	// Handle the timeout up front.
-	var cancel func()
-	if timeoutStr, ok := req.Options[cmds.TimeoutOpt]; ok {
-		timeout, err := time.ParseDuration(timeoutStr.(string))
-		if err != nil {
-			printErr(err)
-			return err
-		}
-		req.Context, cancel = context.WithTimeout(req.Context, timeout)
-	} else if req.Command.RunTimeout != 0 {
-		// Use command default timeout when available
-		req.Context, cancel = context.WithTimeout(req.Context, req.Command.RunTimeout)
-	} else {
-		req.Context, cancel = context.WithCancel(req.Context)
-	}
-	defer cancel()
 
 	// this is a message to tell the user how to get the help text
 	printMetaHelp := func(w io.Writer) {
@@ -104,6 +86,23 @@ func Run(ctx context.Context, root *cmds.Command,
 		printHelp(false, stdout)
 		return nil
 	}
+
+	// Handle the timeout up front.
+	var cancel func()
+	if timeoutStr, ok := req.Options[cmds.TimeoutOpt]; ok {
+		timeout, err := time.ParseDuration(timeoutStr.(string))
+		if err != nil {
+			printErr(err)
+			return err
+		}
+		req.Context, cancel = context.WithTimeout(req.Context, timeout)
+	} else if req.Command.RunTimeout != 0 {
+		// Use command default timeout when available
+		req.Context, cancel = context.WithTimeout(req.Context, req.Command.RunTimeout)
+	} else {
+		req.Context, cancel = context.WithCancel(req.Context)
+	}
+	defer cancel()
 
 	cmd := req.Command
 


### PR DESCRIPTION
1. Modified cli/run.go to check parse error before timeout setting. 
2. Verified http/handler.go checks parse error before timeout set. So does not need to change: https://github.com/TRON-US/go-btfs-cmds/blob/e9ff6db0c3069da5e280dca42c71103e473ad207/http/handler.go#L122